### PR TITLE
Rename everything 'resin' to 'balena'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-resin-auth
+balena-auth
 -----------
 
-[![npm version](https://badge.fury.io/js/resin-auth.svg)](http://badge.fury.io/js/resin-auth)
-[![dependencies](https://david-dm.org/resin-io-modules/resin-auth.png)](https://david-dm.org/resin-io-modules/resin-auth.png)
-[![Build Status](https://travis-ci.org/resin-io-modules/resin-auth.svg?branch=master)](https://travis-ci.org/resin-io-modules/resin-auth)
+[![npm version](https://badge.fury.io/js/balena-auth.svg)](http://badge.fury.io/js/balena-auth)
+[![dependencies](https://david-dm.org/balena-io-modules/balena-auth.png)](https://david-dm.org/balena-io-modules/balena-auth.png)
+[![Build Status](https://travis-ci.org/balena-io-modules/balena-auth.svg?branch=master)](https://travis-ci.org/balena-io-modules/balena-auth)
 
-Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.png)](https://gitter.im/resin-io/chat)
+Join our online chat at [![Gitter chat](https://badges.gitter.im/balena-io/chat.png)](https://gitter.im/balena-io/chat)
 
-Resin.io session authentication utilities
+Balena session authentication utilities
 
 Role
 ----
 
-The intention of this module is to provide low level access to how a Resin.io authentication tokens are parsed and persisted.
+The intention of this module is to provide low level access to how a balena authentication tokens are parsed and persisted.
 
 **THIS MODULE IS LOW LEVEL AND IS NOT MEANT TO BE USED BY END USERS DIRECTLY**.
 
-Unless you know what you're doing, use the [Resin SDK](https://github.com/resin-io/resin-sdk) instead.
+Unless you know what you're doing, use the [balena SDK](https://github.com/balena-io/balena-sdk) instead.
 
 Installation
 ------------
 
-Install `resin-auth` by running:
+Install `balena-auth` by running:
 
 ```sh
-$ npm install --save resin-auth
+$ npm install --save balena-auth
 ```
 
 Documentation
@@ -42,9 +42,9 @@ It accepts the following params:
 
 **Example**
 ```js
-import ResinAuth from 'resin-auth';
-const auth = new ResinAuth({
-	dataDirectory: '/opt/cache/resin',
+import BalenaAuth from 'balena-auth';
+const auth = new BalenaAuth({
+	dataDirectory: '/opt/cache/balena',
 	tokenKey: 'token'
 });
 ```
@@ -164,7 +164,7 @@ auth.needs2FA().then((needs2FA) => { ... });
 Support
 -------
 
-If you're having any problem, please [raise an issue](https://github.com/resin-io-modules/resin-auth/issues/new) on GitHub and the Resin.io team will be happy to help.
+If you're having any problem, please [raise an issue](https://github.com/balena-io-modules/balena-auth/issues/new) on GitHub and the balena team will be happy to help.
 
 Tests
 -----
@@ -178,8 +178,8 @@ $ npm test
 Contribute
 ----------
 
-- Issue Tracker: [github.com/resin-io-modules/resin-auth/issues](https://github.com/resin-io-modules/resin-auth/issues)
-- Source Code: [github.com/resin-io-modules/resin-auth](https://github.com/resin-io-modules/resin-auth)
+- Issue Tracker: [github.com/balena-io-modules/balena-auth/issues](https://github.com/balena-io-modules/balena-auth/issues)
+- Source Code: [github.com/balena-io-modules/balena-auth](https://github.com/balena-io-modules/balena-auth)
 
 Before submitting a PR, please make sure that you include tests, and that [tslint](https://palantir.github.io/tslint/) runs without any warning:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,8 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 'stable'
+    - nodejs_version: 8
     - nodejs_version: 6
-    - nodejs_version: 4
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -1,30 +1,30 @@
-resin-auth
+balena-auth
 -----------
 
-[![npm version](https://badge.fury.io/js/resin-auth.svg)](http://badge.fury.io/js/resin-auth)
-[![dependencies](https://david-dm.org/resin-io-modules/resin-auth.png)](https://david-dm.org/resin-io-modules/resin-auth.png)
-[![Build Status](https://travis-ci.org/resin-io-modules/resin-auth.svg?branch=master)](https://travis-ci.org/resin-io-modules/resin-auth)
+[![npm version](https://badge.fury.io/js/balena-auth.svg)](http://badge.fury.io/js/balena-auth)
+[![dependencies](https://david-dm.org/balena-io-modules/balena-auth.png)](https://david-dm.org/balena-io-modules/balena-auth.png)
+[![Build Status](https://travis-ci.org/balena-io-modules/balena-auth.svg?branch=master)](https://travis-ci.org/balena-io-modules/balena-auth)
 
-Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.png)](https://gitter.im/resin-io/chat)
+Join our online chat at [![Gitter chat](https://badges.gitter.im/balena-io/chat.png)](https://gitter.im/balena-io/chat)
 
-Resin.io session authentication utilities
+Balena session authentication utilities
 
 Role
 ----
 
-The intention of this module is to provide low level access to how a Resin.io authentication tokens are parsed and persisted.
+The intention of this module is to provide low level access to how a balena authentication tokens are parsed and persisted.
 
 **THIS MODULE IS LOW LEVEL AND IS NOT MEANT TO BE USED BY END USERS DIRECTLY**.
 
-Unless you know what you're doing, use the [Resin SDK](https://github.com/resin-io/resin-sdk) instead.
+Unless you know what you're doing, use the [balena SDK](https://github.com/balena-io/balena-sdk) instead.
 
 Installation
 ------------
 
-Install `resin-auth` by running:
+Install `balena-auth` by running:
 
 ```sh
-$ npm install --save resin-auth
+$ npm install --save balena-auth
 ```
 
 Documentation
@@ -42,9 +42,9 @@ It accepts the following params:
 
 **Example**
 ```js
-import ResinAuth from 'resin-auth';
-const auth = new ResinAuth({
-	dataDirectory: '/opt/cache/resin',
+import BalenaAuth from 'balena-auth';
+const auth = new BalenaAuth({
+	dataDirectory: '/opt/cache/balena',
 	tokenKey: 'token'
 });
 ```
@@ -60,7 +60,7 @@ const auth = new ResinAuth({
 Support
 -------
 
-If you're having any problem, please [raise an issue](https://github.com/resin-io-modules/resin-auth/issues/new) on GitHub and the Resin.io team will be happy to help.
+If you're having any problem, please [raise an issue](https://github.com/balena-io-modules/balena-auth/issues/new) on GitHub and the balena team will be happy to help.
 
 Tests
 -----
@@ -74,8 +74,8 @@ $ npm test
 Contribute
 ----------
 
-- Issue Tracker: [github.com/resin-io-modules/resin-auth/issues](https://github.com/resin-io-modules/resin-auth/issues)
-- Source Code: [github.com/resin-io-modules/resin-auth](https://github.com/resin-io-modules/resin-auth)
+- Issue Tracker: [github.com/balena-io-modules/balena-auth/issues](https://github.com/balena-io-modules/balena-auth/issues)
+- Source Code: [github.com/balena-io-modules/balena-auth](https://github.com/balena-io-modules/balena-auth)
 
 Before submitting a PR, please make sure that you include tests, and that [tslint](https://palantir.github.io/tslint/) runs without any warning:
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 const packageJSON = require('./package.json')
-const getKarmaConfig = require('resin-config-karma')
+const getKarmaConfig = require('balena-config-karma')
 
 module.exports = (config) => {
 	const karmaConfig = getKarmaConfig(packageJSON)

--- a/lib/api-key.ts
+++ b/lib/api-key.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2016-17 Resin.io
+Copyright 2016-17 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2016-17 Resin.io
+Copyright 2016-17 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,25 +18,26 @@ limitations under the License.
  * @module auth
  */
 
+import * as errors from 'balena-errors';
+import * as getStorage from 'balena-settings-storage';
+import { BalenaSettingsStorage } from 'balena-settings-storage/lib/types';
 import * as Promise from 'bluebird';
-import * as errors from 'resin-errors';
-import * as getStorage from 'resin-settings-storage';
-import { ResinSettingsStorage } from 'resin-settings-storage/lib/types';
+
 import { APIKey } from './api-key';
 import { JWT } from './jwt';
 import { Token, TokenType } from './token';
 
-interface ResinAuthOptions {
+interface BalenaAuthOptions {
 	dataDirectory?: string;
 	tokenKey?: string;
 }
 
-export default class ResinAuth {
-	private readonly storage: ResinSettingsStorage;
+export default class BalenaAuth {
+	private readonly storage: BalenaSettingsStorage;
 	private readonly tokenKey: string;
 	private token?: Token;
 
-	constructor({ dataDirectory, tokenKey = 'token' }: ResinAuthOptions = {}) {
+	constructor({ dataDirectory, tokenKey = 'token' }: BalenaAuthOptions = {}) {
 		this.storage = getStorage({ dataDirectory });
 		this.tokenKey = tokenKey;
 	}
@@ -188,10 +189,10 @@ export default class ResinAuth {
 	private createToken = (key: string): Token => {
 		const token: Token = JWT.isValid(key) ? new JWT(key) : new APIKey(key);
 		if (!token.isValid()) {
-			throw new errors.ResinMalformedToken(key);
+			throw new errors.BalenaMalformedToken(key);
 		}
 		if (token.isExpired()) {
-			throw new errors.ResinExpiredToken(key);
+			throw new errors.BalenaExpiredToken(key);
 		}
 		return token;
 	};
@@ -203,7 +204,7 @@ export default class ResinAuth {
 
 		return this.storage.get(this.tokenKey).then(key => {
 			if (typeof key !== 'string') {
-				throw new errors.ResinMalformedToken(key as any);
+				throw new errors.BalenaMalformedToken(key as any);
 			}
 			this.token = this.createToken(key as string);
 			return this.token;

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2016-17 Resin.io
+Copyright 2016-17 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2016-17 Resin.io
+Copyright 2016-17 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mochainon": "^2.0.0",
     "prettier": "~1.14.2",
     "require-npm4-to-publish": "^1.0.0",
-    "resin-config-karma": "^2.3.0",
+    "balena-config-karma": "^2.3.0",
     "balena-settings-client": "^4.0.0",
     "rimraf": "^2.6.1",
     "ts-node": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "resin-auth",
+  "name": "balena-auth",
   "version": "2.0.1",
-  "description": "Resin.io session authentication utilities",
+  "description": "Balena session authentication utilities",
   "main": "build/auth.js",
   "types": "lib/*.ts",
-  "homepage": "https://github.com/resin-io-modules/resin-auth",
+  "homepage": "https://github.com/balena-io-modules/balena-auth",
   "repository": {
     "type": "git",
-    "url": "git://github.com/resin-io-modules/resin-auth.git"
+    "url": "git://github.com/balena-io-modules/balena-auth.git"
   },
   "files": [
     "build/",
     "lib/"
   ],
   "keywords": [
-    "resin",
+    "balena",
     "auth",
     "jwt",
     "api-key",
@@ -39,7 +39,7 @@
     "readme": "jsdoc2md --template doc/README.hbs build/*.js > README.md",
     "precommit": "npm run lint && npm run test:node -- --reporter dot"
   },
-  "author": "Resin.io Team <hello@resin.io>",
+  "author": "Balena Team <hello@balena.io>",
   "license": "Apache-2.0",
   "devDependencies": {
     "@resin.io/types-mochainon": "^2.0.1",
@@ -56,7 +56,7 @@
     "prettier": "~1.14.2",
     "require-npm4-to-publish": "^1.0.0",
     "resin-config-karma": "^2.3.0",
-    "resin-settings-client": "^3.7.0",
+    "balena-settings-client": "^4.0.0",
     "rimraf": "^2.6.1",
     "ts-node": "^3.3.0",
     "tslint": "^5.5.0",
@@ -67,7 +67,7 @@
     "@types/jwt-decode": "^2.2.1",
     "bluebird": "^3.0.0",
     "jwt-decode": "^2.1.0",
-    "resin-errors": "^2.8.0",
-    "resin-settings-storage": "^4.0.0"
+    "balena-errors": "^3.0.0",
+    "balena-settings-storage": "^5.0.0"
   }
 }

--- a/tests/03-auth.spec.ts
+++ b/tests/03-auth.spec.ts
@@ -1,5 +1,5 @@
 import { chai } from 'mochainon';
-import ResinAuth from '../lib/auth';
+import BalenaAuth from '../lib/auth';
 import { TokenType } from '../lib/token';
 import apiKeyFixtures from './fixtures/api-keys';
 import jwtFixtures from './fixtures/jwts';
@@ -10,13 +10,13 @@ const IS_BROWSER = typeof window !== 'undefined';
 let dataDirectory;
 if (!IS_BROWSER) {
 	// tslint:disable-next-line no-var-requires
-	const settings = require('resin-settings-client');
+	const settings = require('balena-settings-client');
 	dataDirectory = settings.get('dataDirectory');
 }
 
-const auth = new ResinAuth({ dataDirectory, tokenKey: 'token-test' });
+const auth = new BalenaAuth({ dataDirectory, tokenKey: 'token-test' });
 
-describe('ResinAuth', () => {
+describe('BalenaAuth', () => {
 	beforeEach(() =>
 		// Ensure a clean state before starting
 		auth.removeKey());


### PR DESCRIPTION
Only functional change is that the balena-errors bump means we now return Balena errors, not Resin ones.

Changing this is required because the module is exposed from the SDK as sdk.auth, and the error types used will potentially be exposed by SDK calls too.

Fixes #16
Change-type: major
Signed-off-by: Tim Perry <tim@balena.io>